### PR TITLE
feat(bank): also write zero balance to transient store

### DIFF
--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -357,11 +357,15 @@ func (k BaseSendKeeper) setBalance(ctx context.Context, addr sdk.AccAddress, bal
 			return err
 		}
 
-		k.setTransientBalance(ctx, addr, balance)
+		if err := k.setTransientBalance(ctx, addr, balance); err != nil {
+			return err
+		}
 		return nil
 	}
 
-	k.setTransientBalance(ctx, addr, balance)
+	if err := k.setTransientBalance(ctx, addr, balance); err != nil {
+		return err
+	}
 	return k.Balances.Set(ctx, collections.Join(addr, balance.Denom), balance.Amount)
 }
 


### PR DESCRIPTION
# Context

We need to write updates to transient store so that we know which balance changed within the block => indexer can reflects the changes
Edge case happens when user sends all, account balance becomes zero but that value is not set in transient store => no event for that 0 balance => indexer update nothing => balance not changed => user bad UX

# Changes
- Write transient store in both cases: balance set to 0 and balance set to non-zero

# Test

Now can transfer all tokens **sol, eth** or partially transfer **btc** normally 

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/8e0a5106-7c32-4a8c-8a9f-e911d272e5e1">

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/0e8443aa-88c2-460a-bd62-f35eef44c48b">
