### PR TITLE
feat: add finalizeEvents() for EventStreamI

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -819,7 +819,9 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Request
 	}
 
 	// notifying all events are flushed
-	sdk.FluxEventManagerSingleton.Finalize()
+	if err := sdk.FluxEventManagerSingleton.Finalize(); err != nil {
+		return nil, fmt.Errorf("finalize event err: %w", err)
+	}
 
 	// check after endBlock if we should abort, to avoid propagating the result
 	select {

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -818,6 +818,9 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Request
 		return nil, err
 	}
 
+	// notifying all events are flushed
+	sdk.FluxEventManagerSingleton.Finalize()
+
 	// check after endBlock if we should abort, to avoid propagating the result
 	select {
 	case <-ctx.Done():

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -819,7 +819,7 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Request
 	}
 
 	// notifying all events are flushed
-	if err := sdk.FluxEventManagerSingleton.Finalize(); err != nil {
+	if err := sdk.FluxEventManagerSingleton.FinalizeEvents(); err != nil {
 		return nil, fmt.Errorf("finalize event err: %w", err)
 	}
 

--- a/types/events_flux.go
+++ b/types/events_flux.go
@@ -4,6 +4,7 @@ var EventStreamSingleton interface{}
 
 type EventStreamI interface {
 	ForwardEvents(events ...interface{})
+	Finalize()
 }
 
 type FluxEventManager struct {
@@ -57,6 +58,10 @@ func (fem *FluxEventManager) FlushEndBlockEvents() {
 
 func (fem *FluxEventManager) ClearEndBlockEvents() {
 	fem.endBlockEvents = []interface{}{}
+}
+
+func (fem *FluxEventManager) Finalize() {
+	EventStreamSingleton.(EventStreamI).Finalize()
 }
 
 var FluxEventManagerSingleton = NewFluxEventManager()

--- a/types/events_flux.go
+++ b/types/events_flux.go
@@ -4,7 +4,7 @@ var EventStreamSingleton interface{}
 
 type EventStreamI interface {
 	ForwardEvents(events ...interface{})
-	Finalize() error
+	FinalizeEvents() error
 }
 
 type FluxEventManager struct {
@@ -60,8 +60,8 @@ func (fem *FluxEventManager) ClearEndBlockEvents() {
 	fem.endBlockEvents = []interface{}{}
 }
 
-func (fem *FluxEventManager) Finalize() error {
-	return EventStreamSingleton.(EventStreamI).Finalize()
+func (fem *FluxEventManager) FinalizeEvents() error {
+	return EventStreamSingleton.(EventStreamI).FinalizeEvents()
 }
 
 var FluxEventManagerSingleton = NewFluxEventManager()

--- a/types/events_flux.go
+++ b/types/events_flux.go
@@ -4,7 +4,7 @@ var EventStreamSingleton interface{}
 
 type EventStreamI interface {
 	ForwardEvents(events ...interface{})
-	Finalize()
+	Finalize() error
 }
 
 type FluxEventManager struct {
@@ -60,8 +60,8 @@ func (fem *FluxEventManager) ClearEndBlockEvents() {
 	fem.endBlockEvents = []interface{}{}
 }
 
-func (fem *FluxEventManager) Finalize() {
-	EventStreamSingleton.(EventStreamI).Finalize()
+func (fem *FluxEventManager) Finalize() error {
+	return EventStreamSingleton.(EventStreamI).Finalize()
 }
 
 var FluxEventManagerSingleton = NewFluxEventManager()


### PR DESCRIPTION
# Context
We need to temporarily persisting block events after all events are collected
Emitting events in app endblocker() doesn't allow to have endblockers' events (e.g BalanceUpdateEvent), because they're collected after the callback (since [this](https://github.com/FluxAstromeshLabs/cosmos-sdk/pull/3))

Paired with: https://github.com/FluxAstromeshLabs/fluxd/pull/186

# Changes

This add a function for `EventStreamI`, i.e FinalizeEvents(), in which EventStream will decide to store the endblocker events, at that point, all events are collected

----
Some concerns:

On another choice, we don't need to add another method but can add a flag to EventStream object in fluxd, so that when ForwardEvents(), we know it's endblocker to temporarily persist event on disk.

Its downside is it introduces hidden logics in ForwardEvents(), we might miss something when refactor. Adding another method looks more maintainable
